### PR TITLE
Fix cell datatypes/formatting

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -193,19 +193,23 @@ def setLastRow(rowNum):
     }
 
 
+def deserializeTestResult(textResult):
+    """Encapsulate any transformations here when reading queued result
+    """
+    output = json.loads(textResult)
+    isoDates = ['start', 'end']
+    for date in isoDates:
+        if date in output:
+            output[date] = iso8601stringToDate(output[date])
+    return output
+
+
 def getQueuedResults():
     """Returns array of queued test result JSON objects
     """
-    output = []
     if os.path.exists(RESULT_QUEUE_FILE):
         with open(RESULT_QUEUE_FILE, 'r') as file:
-            for line in file.read().splitlines():
-                raw = json.loads(line)
-                raw['start'] = iso8601stringToDate(raw['start'])
-                if 'end' in raw:
-                    raw['end'] = iso8601stringToDate(raw['end'])
-                output += [raw]
-    return output
+            return map(lambda line: deserializeTestResult(line), file.read().splitlines())
 
 
 def queueResult(thisResult):

--- a/monitor.py
+++ b/monitor.py
@@ -111,7 +111,7 @@ def dateToEpoch(d):
 def iso8601stringToDate(d):
     """Parse ISO8601 datetime string (with optional milliseconds) to date
     """
-    # strptime requires milliseconds, so add if not present
+    # our strptime format requires milliseconds, so add if not present
     if '.' not in d:
         d += '.000000'
     return datetime.datetime.strptime(d, '%Y-%m-%dT%H:%M:%S.%f')

--- a/monitor.py
+++ b/monitor.py
@@ -204,6 +204,10 @@ def deserializeTestResult(textResult):
     return output
 
 
+def serializeTestResult(testResult):
+    return json.dumps(testResult, default=json_serial)
+
+
 def getQueuedResults():
     """Returns array of queued test result JSON objects
     """
@@ -219,7 +223,7 @@ def queueResult(thisResult):
     """
     if thisResult:
         with open(RESULT_QUEUE_FILE, 'a') as file:
-            file.write(json.dumps(thisResult, default=json_serial) + '\n')
+            file.write(serializeTestResult(thisResult) + '\n')
         return True
     else:
         return False

--- a/monitor.py
+++ b/monitor.py
@@ -210,6 +210,8 @@ def getQueuedResults():
     if os.path.exists(RESULT_QUEUE_FILE):
         with open(RESULT_QUEUE_FILE, 'r') as file:
             return map(lambda line: deserializeTestResult(line), file.read().splitlines())
+    else:
+        return []
 
 
 def queueResult(thisResult):

--- a/monitor.py
+++ b/monitor.py
@@ -108,6 +108,15 @@ def dateToEpoch(d):
     return delta.total_seconds() / (3600 * 24)
 
 
+def iso8601stringToDate(d):
+    """Parse ISO8601 datetime string (with optional milliseconds) to date
+    """
+    # strptime requires milliseconds, so add if not present
+    if '.' not in d:
+        d += '.000000'
+    return datetime.datetime.strptime(d, '%Y-%m-%dT%H:%M:%S.%f')
+
+
 def connectionTestRow(result):
     """Results are stored in form
     {start}, {end}, {success count}, {failure count}
@@ -192,9 +201,9 @@ def getQueuedResults():
         with open(RESULT_QUEUE_FILE, 'r') as file:
             for line in file.read().splitlines():
                 raw = json.loads(line)
-                raw['start'] = datetime.datetime.strptime(raw['start'], '%Y-%m-%dT%H:%M:%S.%f')
+                raw['start'] = iso8601stringToDate(raw['start'])
                 if 'end' in raw:
-                    raw['end'] = datetime.datetime.strptime(raw['end'], '%Y-%m-%dT%H:%M:%S.%f')
+                    raw['end'] = iso8601stringToDate(raw['end'])
                 output += [raw]
     return output
 


### PR DESCRIPTION
Date columns should be uploaded as numeric (float: days since Dec. 30 1899 epoch) instead of string. This will allow cells to be formatted correctly as dates, durations to be calculated, etc.
